### PR TITLE
Low time music-related changes

### DIFF
--- a/animation.lua
+++ b/animation.lua
@@ -466,9 +466,16 @@ function animation:update(dt)
 					if v[2] == "star" then
 						musicname = "starmusic"
 					end
+					for i, m in pairs(music.list) do
+						if m == musicname then
+							musici = i + 1 -- plus one because of the none music being number 1
+						end
+					end
 					for i, m in pairs(custommusics) do
 						if m == mappackfolder .. "/" .. mappack .. "/" .. musicname then
 							musicname = m
+							musici = 7
+							custommusic = musicname
 						end
 					end
 					music:play(musicname)

--- a/editor.lua
+++ b/editor.lua
@@ -276,6 +276,8 @@ function editor_load(player_position) --{x, y, xscroll, yscroll}
 	guielements["realtimecheckbox"] = guielement:new("checkbox", 294, 154, togglerealtime, realtime, TEXT["real time"])
 	local _, count = TEXT["real time"]:gsub("\n", '')
 	guielements["continuemusiccheckbox"] = guielement:new("checkbox", 294, guielements["realtimecheckbox"].y+11+10*count, togglecontinuemusic, continuesublevelmusic, TEXT["cont. music"])
+	_, count = TEXT["cont. music"]:gsub("\n", '')
+	guielements["nolowtimecheckbox"] = guielement:new("checkbox", 294, guielements["continuemusiccheckbox"].y+11+10*count, togglenolowtime, nolowtime, TEXT["no low time"])
 
 	--MAPS
 	guielements["savebutton2"] = guielement:new("button", 300, 196, TEXT["save level"], guielements["savebutton"].func, 0, nil, 2.4, 94, true)
@@ -2691,6 +2693,7 @@ function editor_draw()
 			guielements["dropshadowcheckbox"]:draw()
 			guielements["realtimecheckbox"]:draw()
 			guielements["continuemusiccheckbox"]:draw()
+			guielements["nolowtimecheckbox"]:draw()
 			
 			properprintF(TEXT["lives:"], 228*scale, 106*scale)
 			guielements["livesincrease"]:draw()
@@ -3343,6 +3346,7 @@ function toolstab()
 	guielements["dropshadowcheckbox"].active = true
 	guielements["realtimecheckbox"].active = true
 	guielements["continuemusiccheckbox"].active = true
+	guielements["nolowtimecheckbox"].active = true
 end
 
 function mapstab()
@@ -7397,6 +7401,9 @@ function savesettings()
 	if continuesublevelmusic then
 		s = s .. "continuesublevelmusic=t\n"
 	end
+	if nolowtime then
+		s = s .. "nolowtime=t\n"
+	end
 	
 	love.filesystem.createDirectory( mappackfolder )
 	love.filesystem.createDirectory( mappackfolder .. "/" .. mappack )
@@ -7627,6 +7634,14 @@ function togglecontinuemusic(var)
 	guielements["continuemusiccheckbox"].var = continuesublevelmusic
 end
 
+function togglenolowtime(var)
+	if var ~= nil then
+		nolowtime = var
+	else
+		nolowtime = not nolowtime
+	end
+	guielements["nolowtimecheckbox"].var = nolowtime
+end
 
 function updatescrollfactor()
 	--not a scrollfactor lol

--- a/game.lua
+++ b/game.lua
@@ -46,6 +46,7 @@ function game_load(suspended)
 	dropshadow = false
 	realtime = false
 	continuesublevelmusic = false
+	nolowtime = false
 	nocoinlimit = false
 	setphysics(1)
 	if love.filesystem.exists(mappackfolder .. "/" .. mappack .. "/settings.txt") and not dcplaying then
@@ -69,6 +70,8 @@ function game_load(suspended)
 				nocoinlimit = true
 			elseif s2[1] == "continuesublevelmusic" then
 				continuesublevelmusic = true
+			elseif s2[1] == "nolowtime" then
+				nolowtime = true
 			elseif s2[1] == "character" then
 				for i = 1, players do
 					setcustomplayer(s2[2], i)
@@ -358,7 +361,7 @@ function game_update(dt)
 			if queuelowtime then
 				queuelowtime = queuelowtime - 2.5*dt
 			end
-			if mariotime > 0 and mariotime + 2.5*dt >= 99 and mariotime < 99 and (not dcplaying) and (not levelfinished) then
+			if mariotime > 0 and mariotime + 2.5*dt >= 99 and mariotime < 99 and (not dcplaying) and (not levelfinished) and not nolowtime then
 				startlowtime()
 			end
 			
@@ -8181,10 +8184,10 @@ function playmusic()
 	end
 	if musici >= 7 then
 		if custommusic then
-			music:play(custommusic, (mariotime < 100 and mariotime > 0))
+			music:play(custommusic, not nolowtime and (mariotime < 100 and mariotime > 0))
 		end
 	elseif musici ~= 1 then
-		music:playIndex(musici-1, (mariotime < 100 and mariotime > 0))
+		music:playIndex(musici-1, not nolowtime and (mariotime < 100 and mariotime > 0))
 	end
 end
 

--- a/languages/english.json
+++ b/languages/english.json
@@ -224,6 +224,7 @@
 		"drop shadow may\nreduce performance!": "drop shadow may\nreduce performance!",
 		"real time": "real time",
 		"cont. music": "cont. music",
+		"no low time": "no low time",
 		"save settings": "save settings",
 		"tool descriptions": [
 			"to link testing equipment, drag\na line from the red devices to\na yellow activator to turn them\ngreen and connected.",


### PR DESCRIPTION
This pull request adds two low time music-related changes, both of which were suggested by Rikifive on the forum:
1/ Adds a checkbox in the TOOLS section to disable the low time warning and fast music
2/ Fixes music changes from animations not persisting after the low time warning