### PR TITLE
Make things not run into grinders

### DIFF
--- a/enemies/grinder.lua
+++ b/enemies/grinder.lua
@@ -20,6 +20,9 @@ function grinder:init(x, y, t)
 	self.static = true
 	self.active = true
 
+	self.NOEXTERNALHORCOLLISIONS = true
+	self.NOEXTERNALVERCOLLISIONS = true
+
 	self.category = 4
 	self.gravity = 0
 	


### PR DESCRIPTION
Character enemies that use category 3 are prone to running into grinders