### PR TITLE
Make Hitting Things From Below Blocks Not Suck

### DIFF
--- a/mario.lua
+++ b/mario.lua
@@ -7131,6 +7131,7 @@ function hitblock(x, y, t, v)
 end
 
 function hitontop(x, y)
+	if breakoutmode then return end
 	--kill enemies on top
 	for i, v in pairs(enemies) do
 		if objects[v] then

--- a/mario.lua
+++ b/mario.lua
@@ -7136,8 +7136,8 @@ function hitontop(x, y)
 		if objects[v] then
 			for j, w in pairs(objects[v]) do
 				if w.width and (w.active or w.killedfromblocksbelownotactive) then
-					local centerX = w.x + w.width/2
-					if inrange(centerX, x-1, x, true) and y-1 == w.y+w.height then
+					local cx = math.max(x-1,math.min(x,w.x))
+					if inrange(cx, w.x, w.x+w.width, true) and inrange(w.y+w.height, y-1, y-1.125, true) then
 						--get dir
 						local dir = "right"
 						if w.x+w.width/2 < x-0.5 then


### PR DESCRIPTION
Formerly only the single block the enemy is centered over could be hit to kill it, but now any block it's over will work.
This should alleviate a lot of frustration with hammer bros and large enemies in particular

![Block Hit Fix](https://media.discordapp.net/attachments/355888508398993408/985584673314996355/Fun_fact.gif?width=400&height=224)
