### PR TITLE
Clear animated tile caches

### DIFF
--- a/game.lua
+++ b/game.lua
@@ -4823,6 +4823,7 @@ function loadmap(filename)
 
 	--ANIMATED TIMERS
 	animatedtimers = {}
+	animatedtimerlist = {}
 	for x = 1, mapwidth do
 		animatedtimers[x] = {}
 	end

--- a/game.lua
+++ b/game.lua
@@ -4806,6 +4806,7 @@ function loadmap(filename)
 	for i = 1, #animatedtiles do
 		if animatedtiles[i].cache then
 			animatedtiles[i].cache = {}
+			tilequads[i+90000].cache = {}
 		end
 	end
 


### PR DESCRIPTION
Animated tile caches are not cleared, and it builds up in ram every time a level with animated tiles is loaded