### PR TITLE
Add support for 8 local players

### DIFF
--- a/characters.lua
+++ b/characters.lua
@@ -528,6 +528,7 @@ function splitimage(img, color, exclude, imagedata) --split singe image into col
 end
 
 function setcustomplayer(i, pn, initial) --name, player number, initial (don't change colors to defaults)
+	print("setcustomplayer(i, pn, initial)", i, pn, initial)
 	if i and characters.data[i] then
 		if love.filesystem.getInfo("alesans_entities/characters/" .. i .. "/config.txt") then
 			--incompatible probably
@@ -589,19 +590,22 @@ function setcustomplayer(i, pn, initial) --name, player number, initial (don't c
 		if not characters.data[i]["quads"] then
 			loadplayerquads(characters.data[i])
 		end
-		if characters.data[i].defaultcolors and characters.data[i].defaultcolors[pn] then
-			if (not initial) or (mariocolors[pn] and #mariocolors[pn] < #characters.data[i].defaultcolors[pn]) then
-				--this doesn't work correctly
-				--for some reason the number of mario colors is always 4
-				--i dont fuckin know
-				--print(initial, #mariocolors[pn], #characters.data[i].defaultcolors[pn])
-				if #characters.data[i].defaultcolors[pn] >= #characters.data[i].colorables then
-					for j = 1, #characters.data[i].colorables do
-						if characters.data[i].defaultcolors[pn][j] then
-							mariocolors[pn][j] = shallowcopy(characters.data[i].defaultcolors[pn][j])
-						else
-							print("missing colorable:" .. j)
-						end
+
+		local color_index = pn
+		if characters.data[i].defaultcolors and pn > #characters.data[i].defaultcolors then
+			color_index = (pn % #characters.data[i].defaultcolors) + 1
+		end
+		--print("name ", i, " characters.data[i].defaultcolors: ", characters.data[i].defaultcolors, "characters.data[i].defaultcolors[color_index]", characters.data[i].defaultcolors[color_index])
+
+		if characters.data[i].defaultcolors and characters.data[i].defaultcolors[color_index] then
+			--print("#mariocolors[pn]: ", #mariocolors[pn], "#characters.data[i].defaultcolors[color_index]", #characters.data[i].defaultcolors[color_index])
+			if (not initial) or (mariocolors[pn] and #mariocolors[pn] < #characters.data[i].defaultcolors[color_index]) then
+				mariocolors[pn] = {}
+				for j = 1, #characters.data[i].colorables do
+					if characters.data[i].defaultcolors[color_index][j] then
+						mariocolors[pn][j] = shallowcopy(characters.data[i].defaultcolors[color_index][j])
+					else
+						print("missing colorable:" .. j)
 					end
 				end
 				if characters.data[i].defaulthat and not initial then

--- a/main.lua
+++ b/main.lua
@@ -102,6 +102,8 @@ local loadingbardraw = function(add)
 end
 
 function love.load()
+	LOCAL_PLAYERS = 8
+
 	loadingbarv = 0
 
 	marioversion = 1006
@@ -1248,14 +1250,18 @@ function saveconfig()
 	
 	if mariocharacter then
 		s = s .. "mariocharacter:"
-		for i = 1, 4 do
+		for i = 1, LOCAL_PLAYERS do
 			if mariocharacter[i] then
-				s = s .. mariocharacter[i] .. ","
+				s = s .. mariocharacter[i]
 			else
-				s = s .. "mario,"
+				s = s .. "mario"
+			end
+			if i < #mariocharacter then
+				s = s .. ","
+			else
+				s = s ..";"
 			end
 		end
-		s = s .. ";"
 	end
 	
 	for i = 1, #mariocolors do
@@ -1370,10 +1376,13 @@ function loadconfig(nodefaultconfig)
 	
 	local s
 	if love.filesystem.getInfo("alesans_entities/options.txt") then
+		print("Found alesans options")
 		s = love.filesystem.read("alesans_entities/options.txt")
 	elseif love.filesystem.getInfo("options.txt") then
+		print("Found default options")
 		s = love.filesystem.read("options.txt")
 	else
+		print("no options found")
 		return
 	end
 	
@@ -1500,6 +1509,7 @@ function loadconfig(nodefaultconfig)
 			localnick = s2[2]
 		elseif s2[1] == "mariocharacter" then
 			local s3 = s2[2]:split(",")
+			print("mariocharacter before for", #mariocharacter)
 			for i = 1, #s3 do
 				if s3[i] == "false" then
 					mariocharacter[i] = "mario"
@@ -1507,6 +1517,7 @@ function loadconfig(nodefaultconfig)
 					mariocharacter[i] = s3[i]
 				end
 			end
+			print("mariocharacter after for", #mariocharacter)
 		end
 	end
 	
@@ -1553,7 +1564,7 @@ function defaultconfig()
 	controls[i]["use"] = {"e"}
 	controls[i]["pause"] = {""}
 	
-	for i = 2, 4 do
+	for i = 2, LOCAL_PLAYERS do
 		controls[i] = {}
 		controls[i]["right"] = {"joy", i-1, "hat", 1, "r"}
 		controls[i]["left"] = {"joy", i-1, "hat", 1, "l"}
@@ -1575,15 +1586,15 @@ function defaultconfig()
 	
 	portalhues = {}
 	portalcolor = {}
-	for i = 1, 4 do
-		local players = 4
+	for i = 1, LOCAL_PLAYERS do
+		local players = LOCAL_PLAYERS
 		portalhues[i] = {(i-1)*(1/players), (i-1)*(1/players)+0.5/players}
 		portalcolor[i] = {getrainbowcolor(portalhues[i][1]), getrainbowcolor(portalhues[i][2])}
 	end
 	
 	--hats.
 	mariohats = {}
-	for i = 1, 4 do
+	for i = 1, LOCAL_PLAYERS do
 		mariohats[i] = {1}
 	end
 	
@@ -1599,11 +1610,15 @@ function defaultconfig()
 	mariocolors[2] = {{      1,       1,       1}, {      0, 160/255,       0}, {252/255, 152/255,  56/255}}
 	mariocolors[3] = {{      0,       0,       0}, {200/255,  76/255,  12/255}, {252/255, 188/255, 176/255}}
 	mariocolors[4] = {{ 32/255,  56/255, 236/255}, {      0, 128/255, 136/255}, {252/255, 152/255,  56/255}}
-	for i = 5, players do
+	for i = 5, LOCAL_PLAYERS do
 		mariocolors[i] = mariocolors[math.random(4)]
 	end
-
-	mariocharacter = {"mario", "mario", "mario", "mario"}
+	print("players: ", players)
+    print("mariocolors: ", #mariocolors)
+	mariocharacter = {}
+	for i=1, LOCAL_PLAYERS do
+		mariocharacter[i] = "mario"
+	end
 	
 	--options
 	scale = 2

--- a/mario.lua
+++ b/mario.lua
@@ -197,7 +197,7 @@ function mario:init(x, y, i, animation, size, t, properties)
 	
 	self.customscissor = nil
 	
-	if (players == 1 and (not CustomPortalColors)) or self.playernumber > 4 then
+	if (players == 1 and (not CustomPortalColors)) or self.playernumber > LOCAL_PLAYERS then
 		self.portal1color = getDefaultPortalColor(1)
 		self.portal2color = getDefaultPortalColor(2)
 	else

--- a/menu.lua
+++ b/menu.lua
@@ -446,7 +446,7 @@ function menu_draw()
 		end
 	end]]
 	
-	for j = 1, math.min(4, players) do
+	for j = 1, math.min(LOCAL_PLAYERS, players) do
 		local char = mariocharacter[j]
 		local v = characters.data[char]
 		if (not v) or (not v["animations"]) then
@@ -466,7 +466,7 @@ function menu_draw()
 		for k = 1, #v.colorables do
 			if v["animations"] then
 				love.graphics.setColor(unpack(mariocolors[j][k] or {0,0,0}))
-				love.graphics.draw(v["animations"][k], v["small"]["idle"][idlei], (startx*16-6+v.smalloffsetX)*scale+8*(j-1)*scale, (starty*16-12-v.smalloffsetY)*scale, 0, scale, scale, v.smallquadcenterX, v.smallquadcenterY)
+				love.graphics.draw(v["animations"][k], v["small"]["idle"][idlei], (startx*16-26+v.smalloffsetX)*scale+8*(j-1)*scale, (starty*16-12-v.smalloffsetY)*scale, 0, scale, scale, v.smallquadcenterX, v.smallquadcenterY)
 			end
 		end
 		
@@ -477,18 +477,18 @@ function menu_draw()
 				local yadd = 0
 				for i = 1, #mariohats[j] do
 					love.graphics.setColor(1, 1, 1)
-					love.graphics.draw(hat[mariohats[j][i]].graphic, hat[mariohats[j][i]].quad[1], (startx*16-6+v.smalloffsetX)*scale+8*(j-1)*scale, (starty*16-12-v.smalloffsetY)*scale, 0, scale, scale, v.smallquadcenterX - hat[mariohats[j][i]].x + offsets[1], v.smallquadcenterY - hat[mariohats[j][i]].y + offsets[2] + yadd)
+					love.graphics.draw(hat[mariohats[j][i]].graphic, hat[mariohats[j][i]].quad[1], (startx*16-26+v.smalloffsetX)*scale+8*(j-1)*scale, (starty*16-12-v.smalloffsetY)*scale, 0, scale, scale, v.smallquadcenterX - hat[mariohats[j][i]].x + offsets[1], v.smallquadcenterY - hat[mariohats[j][i]].y + offsets[2] + yadd)
 					yadd = yadd + (hat[mariohats[j][i]].height or 0)
 				end
 			elseif #mariohats[j] == 1 then
 				love.graphics.setColor(mariocolors[j][1])
-				love.graphics.draw(hat[mariohats[j][1]].graphic, hat[mariohats[j][1]].quad[1], (startx*16-6+v.smalloffsetX)*scale+8*(j-1)*scale, (starty*16-12-v.smalloffsetY)*scale, 0, scale, scale, v.smallquadcenterX - hat[mariohats[j][1]].x + offsets[1], v.smallquadcenterY - hat[mariohats[j][1]].y + offsets[2])
+				love.graphics.draw(hat[mariohats[j][1]].graphic, hat[mariohats[j][1]].quad[1], (startx*16-26+v.smalloffsetX)*scale+8*(j-1)*scale, (starty*16-12-v.smalloffsetY)*scale, 0, scale, scale, v.smallquadcenterX - hat[mariohats[j][1]].x + offsets[1], v.smallquadcenterY - hat[mariohats[j][1]].y + offsets[2])
 			end
 		end
 		
 		if v["animations"] then
 			love.graphics.setColor(1, 1, 1, 1)
-			love.graphics.draw(v["animations"][0], v["small"]["idle"][idlei], (startx*16-6+v.smalloffsetX)*scale+8*(j-1)*scale, (starty*16-12-v.smalloffsetY)*scale, 0, scale, scale, v.smallquadcenterX, v.smallquadcenterY)
+			love.graphics.draw(v["animations"][0], v["small"]["idle"][idlei], (startx*16-26+v.smalloffsetX)*scale+8*(j-1)*scale, (starty*16-12-v.smalloffsetY)*scale, 0, scale, scale, v.smallquadcenterX, v.smallquadcenterY)
 		end
 	end
 	
@@ -1148,6 +1148,7 @@ function menu_draw()
 			love.graphics.setColor(1, 1, 1, 1)
 			for i = 1, #v.colorables do
 				if mariocolors[skinningplayer][i] then
+					--print("mariocolors: ", #mariocolors, " skinningplayer: ", skinningplayer, " i: ", i)
 					love.graphics.setColor(unpack(mariocolors[skinningplayer][i]))
 				end
 				if mariocharacter[skinningplayer] then
@@ -1201,6 +1202,7 @@ function menu_draw()
 					love.graphics.draw(v["animations"][0], v["small"]["jump"][3][1], (152+v.smalloffsetX)*scale, (2+((j-1)*32)+infmarioY-v.smalloffsetY)*scale, infmarioR, scale, scale, v.smallquadcenterX, v.smallquadcenterY)
 				end
 				for i = 1, #v.colorables do
+					--print(#v.colorables, #mariocolors, skinningplayer, i, #mariocolors[skinningplayer])
 					love.graphics.setColor(unpack(mariocolors[skinningplayer][i]))
 					love.graphics.draw(v["animations"][i], v["small"]["jump"][3][1], (152+v.smalloffsetX)*scale, (2+((j-1)*32)+infmarioY-v.smalloffsetY)*scale, infmarioR, scale, scale, v.smallquadcenterX, v.smallquadcenterY)
 				end
@@ -2207,8 +2209,8 @@ function menu_keypressed(key, unicode)
 			end
 		elseif (key == "right" or key == "d") then
 			players = players + 1
-			if players > 4 then
-				players = 4
+			if players > LOCAL_PLAYERS then
+				players = LOCAL_PLAYERS
 			end
 		end
 	elseif gamestate == "mappackmenu" then
@@ -2381,7 +2383,7 @@ function menu_keypressed(key, unicode)
 				end
 			elseif (key == "right" or key == "d") then
 				if optionstab == 2 or optionstab == 1 then
-					if skinningplayer < 4 then
+					if skinningplayer < LOCAL_PLAYERS then
 						skinningplayer = skinningplayer + 1
 						characteri = characters.data[mariocharacter[skinningplayer]].i
 						if players > #controls then


### PR DESCRIPTION
Changes:
* Add support for up to 8 local players. Changing max number of players can be done by changing the value of LOCAL_PLAYERS.
* Remove a redundant trailing comma when saving config.
* Fixed the issue with "for some reason the number of mario colors is always 4". When updating, the old array wasn't removed so if a character was once selected which supported 4 colors then it never went back to 3 colors when switching to a character with 3 colors.

I have only tested that it works for local play on Windows.