### PR TITLE
Removed `"only_for_alesans_entities"`

### DIFF
--- a/alesans_entities/mappacks/alesans_entities_mappack/text.txt
+++ b/alesans_entities/mappacks/alesans_entities_mappack/text.txt
@@ -11,5 +11,5 @@ hudsimple=false
 toadtext=thank you mario!,but our princess is in,another castle!
 peachtext=thank you mario!,your quest is over.,we present you a new quest.,push button b,to play as steve
 steve=true
-levelscreen=1|1|
+levelscreen=1|1|mappack by alesan99
 hudhidecollectables=f,f,f,f,f,f,f,f,f,f

--- a/levelscreen.lua
+++ b/levelscreen.lua
@@ -335,9 +335,6 @@ function levelscreen_draw()
 					end
 				end
 				properprintfunc(s, (width/2*16)*scale-string.len(s)*4*scale, 200*scale)
-			elseif mappack == "only_for_alesans_entities" and marioworld == 1 and mariolevel == 1 then
-				local s = "mappack by alesan99"
-				properprintfunc(s, (width/2*16)*scale-string.len(s)*4*scale, 200*scale)
 			elseif levelscreentext[marioworld .. "-" .. mariolevel] then
 				local s = levelscreentext[marioworld .. "-" .. mariolevel]
 				properprintbasicfunc(s, (width/2*16)*scale-string.len(s)*4*scale, 200*scale)

--- a/mappacks/alesans_entities_mappack/text.txt
+++ b/mappacks/alesans_entities_mappack/text.txt
@@ -11,5 +11,5 @@ hudsimple=false
 toadtext=thank you mario!,but our princess is in,another castle!
 peachtext=thank you mario!,your quest is over.,we present you a new quest.,push button b,to play as steve
 steve=true
-levelscreen=1|1|
+levelscreen=1|1|mappack by alesan99
 hudhidecollectables=f,f,f,f,f,f,f,f,f,f

--- a/menu.lua
+++ b/menu.lua
@@ -3083,7 +3083,6 @@ end
 function reset_mappacks()
 	delete_mappack("smb")
 	delete_mappack("portal")
-	delete_mappack("only_for_alesans_entities")
 	delete_mappack("alesans_entities_mappack")
 
 	--[[local dlclist = love.filesystem.getDirectoryItems("alesans_entities/onlinemappacks/")


### PR DESCRIPTION
Softcoded the caption for the AE Mappack and removed the `"only_for_alesans_entities"` mappack string as it's not used, and the caption doesn't have any control inputs making it possible to softcode without anything extreme