### PR TITLE
Add per-mappack suspend/save support with the option for map creators to save progress automatically

### DIFF
--- a/animation.lua
+++ b/animation.lua
@@ -79,6 +79,7 @@ instantkillplayer[:player]			kills player(s)
 disablejumping						disable jumping
 enablejumping						enables jumping
 
+autosave							saves mappack progress
 changebackground:background			changes background
 changeforeground:background	 	    changes foreground
 removecoins:amount					removes coins
@@ -754,6 +755,11 @@ function animation:update(dt)
 						objects["player"][i].speedx = tonumber(sx) or 0
 						objects["player"][i].speedy = tonumber(sy) or 0
 					end
+				end
+			elseif v[1] == "autosave" then
+				savegame()
+				if v[2] == true then
+					notice.new("game saved!", notice.white, 3)
 				end
 			elseif v[1] == "changebackground" then
 				if v[2] then

--- a/animation.lua
+++ b/animation.lua
@@ -757,9 +757,9 @@ function animation:update(dt)
 					end
 				end
 			elseif v[1] == "autosave" then
-				savegame()
+				writesuspendfile()
 				if v[2] == true then
-					notice.new("game saved!", notice.white, 3)
+					notice.new(TEXT["game saved!"], notice.white, 3)
 				end
 			elseif v[1] == "changebackground" then
 				if v[2] then

--- a/animation.lua
+++ b/animation.lua
@@ -758,7 +758,7 @@ function animation:update(dt)
 				end
 			elseif v[1] == "autosave" then
 				-- only save if the game is being played offline
-				if not (CLIENT or SERVER) then
+				if not (CLIENT or SERVER or dcplaying) then
 					-- don't save if the game is being played in the editor
 					if not testlevel then
 						writesuspendfile()

--- a/animation.lua
+++ b/animation.lua
@@ -757,9 +757,16 @@ function animation:update(dt)
 					end
 				end
 			elseif v[1] == "autosave" then
-				writesuspendfile()
-				if v[2] == true then
-					notice.new(TEXT["game saved!"], notice.white, 3)
+				-- only save if the game is being played offline
+				if not (CLIENT or SERVER) then
+					-- don't save if the game is being played in the editor
+					if not testlevel then
+						writesuspendfile()
+					end
+					-- show notice regardless of whether player is in editor or not, to prove the function works while testing
+					if v[2] == true then
+						notice.new(TEXT["game saved!"], notice.white, 3)
+					end
 				end
 			elseif v[1] == "changebackground" then
 				if v[2] then

--- a/animationguiline.lua
+++ b/animationguiline.lua
@@ -1390,6 +1390,22 @@ table.insert(toenter, {name = "changebackground",
 	}
 })
 
+table.insert(toenter, {name = "autosave", 
+	t = {
+		t="action",
+		nicename="save game progress",
+		entries={
+			{
+				t="text",
+				value=" and "
+			},
+			{
+				t="notifyplayer"
+			}
+		}
+	}
+})
+
 table.insert(toenter, {name = "changeforeground", 
 	t = {
 		t="action",
@@ -2144,6 +2160,12 @@ function animationguiline:init(tabl, t2)
 					dropwidth = 6
 					args = {"both","none","1 only","2 only","gel"}
 					displayargs = {"both","none","1 only","2 only","gel"}
+				
+				elseif v.t == "notifyplayer" then
+					dropdown = true
+					dropwidth = 24
+					args = {true, false}
+					displayargs = {"notify the player", "don't notify the player"}
 				end
 				
 				if dropdown then

--- a/game.lua
+++ b/game.lua
@@ -1,6 +1,6 @@
 local queuespritebatchupdate = false
 
-function game_load(suspended)
+function game_load(suspended, deletesuspend)
 	scrollfactor = 0
 	scrollfactory = 0
 	scrollfactor2 = 0
@@ -97,6 +97,11 @@ function game_load(suspended)
 		marioworld = suspended
 	end
 	
+	if deletesuspend then
+		-- On starting a new game, remove the old save
+		love.filesystem.remove(savesfolder .. "/" .. mappack .. ".suspend")
+	end
+
 	--remove custom sprites
 	for i = smbtilecount+portaltilecount+1, #tilequads do
 		tilequads[i] = nil

--- a/game.lua
+++ b/game.lua
@@ -48,6 +48,7 @@ function game_load(suspended, deletesuspend)
 	continuesublevelmusic = false
 	nolowtime = false
 	nocoinlimit = false
+	alwaysdeletesuspend = false
 	setphysics(1)
 	if not dcplaying then
 		loadmappacksettings()
@@ -97,7 +98,7 @@ function game_load(suspended, deletesuspend)
 		marioworld = suspended
 	end
 	
-	if deletesuspend then
+	if deletesuspend or alwaysdeletesuspend then
 		-- On starting a new game, remove the old save
 		love.filesystem.remove(savesfolder .. "/" .. mappack .. ".suspend")
 	end
@@ -2869,6 +2870,8 @@ function game_draw()
 			end
 			if dcplaying and pausemenuoptions[i] == "save game" then --restart instead of suspend
 				properprintF(TEXT["restart"], (width*8*scale)-35*scale, (112*scale)-60*scale+(i-1)*25*scale)
+			elseif alwaysdeletesuspend and pausemenuoptions[i] == "save game" then
+				properprintF(TEXT["suspend"], (width*8*scale)-35*scale, (112*scale)-60*scale+(i-1)*25*scale)
 			else
 				properprintF(TEXT[pausemenuoptions[i]], (width*8*scale)-35*scale, (112*scale)-60*scale+(i-1)*25*scale)
 			end
@@ -2929,8 +2932,13 @@ function game_draw()
 			love.graphics.rectangle("fill", (width*8*scale)-100*scale, (112*scale)-25*scale, 200*scale, 50*scale)
 			love.graphics.setColor(1, 1, 1, 1)
 			drawrectangle((width*8)-99, 112-24, 198, 48)
-			properprintF(TEXT["save game? this will"], (width*8*scale)-utf8.len(TEXT["save game? this will"])*4*scale, (112*scale)-20*scale)
-			properprintF(TEXT["overwrite last save."], (width*8*scale)-utf8.len(TEXT["overwrite last save."])*4*scale, (112*scale)-10*scale)
+			if alwaysdeletesuspend then
+				properprintF(TEXT["suspend game? this can"], (width*8*scale)-utf8.len(TEXT["suspend game? this can"])*4*scale, (112*scale)-20*scale)
+				properprintF(TEXT["only be loaded once!"], (width*8*scale)-utf8.len(TEXT["only be loaded once!"])*4*scale, (112*scale)-10*scale)
+			else
+				properprintF(TEXT["save game? this will"], (width*8*scale)-utf8.len(TEXT["save game? this will"])*4*scale, (112*scale)-20*scale)
+				properprintF(TEXT["overwrite last save."], (width*8*scale)-utf8.len(TEXT["overwrite last save."])*4*scale, (112*scale)-10*scale)
+			end
 			if pausemenuselected2 == 1 then
 				properprintF(">", (width*8*scale)-51*scale, (112*scale)+4*scale)
 				love.graphics.setColor(1, 1, 1, 1)

--- a/game.lua
+++ b/game.lua
@@ -2867,13 +2867,8 @@ function game_draw()
 				love.graphics.setColor(1, 1, 1, 1)
 				properprint(">", (width*8*scale)-45*scale, (112*scale)-60*scale+(i-1)*25*scale)
 			end
-			if dcplaying and pausemenuoptions[i] == "suspend" then --restart instead of suspend
+			if dcplaying and pausemenuoptions[i] == "save game" then --restart instead of suspend
 				properprintF(TEXT["restart"], (width*8*scale)-35*scale, (112*scale)-60*scale+(i-1)*25*scale)
-			elseif (collectablescount[1] > 0 or collectablescount[2] > 0 or collectablescount[3] > 0 or collectablescount[4] > 0 or
-			collectablescount[5] > 0 or collectablescount[6] > 0 or collectablescount[7] > 0 or collectablescount[8] > 0 or
-			collectablescount[9] > 0 or collectablescount[10] > 0)
-				and pausemenuoptions[i] == "suspend" then --make it more obvious that you can save your progress
-				properprintF(TEXT["save game"], (width*8*scale)-35*scale, (112*scale)-60*scale+(i-1)*25*scale)
 			else
 				properprintF(TEXT[pausemenuoptions[i]], (width*8*scale)-35*scale, (112*scale)-60*scale+(i-1)*25*scale)
 			end
@@ -2934,15 +2929,8 @@ function game_draw()
 			love.graphics.rectangle("fill", (width*8*scale)-100*scale, (112*scale)-25*scale, 200*scale, 50*scale)
 			love.graphics.setColor(1, 1, 1, 1)
 			drawrectangle((width*8)-99, 112-24, 198, 48)
-			if (collectablescount[1] > 0 or collectablescount[2] > 0 or collectablescount[3] > 0 or collectablescount[4] > 0 or
-			collectablescount[5] > 0 or collectablescount[6] > 0 or collectablescount[7] > 0 or collectablescount[8] > 0 or
-			collectablescount[9] > 0 or collectablescount[10] > 0) then --make it more obvious that you can save your progress
-				properprintF(TEXT["save game? this will"], (width*8*scale)-utf8.len(TEXT["save game? this will"])*4*scale, (112*scale)-20*scale)
-				properprintF(TEXT["overwrite last save."], (width*8*scale)-utf8.len(TEXT["overwrite last save."])*4*scale, (112*scale)-10*scale)
-			else
-				properprintF(TEXT["suspend game? this can"], (width*8*scale)-utf8.len(TEXT["suspend game? this can"])*4*scale, (112*scale)-20*scale)
-				properprintF(TEXT["only be loaded once!"], (width*8*scale)-utf8.len(TEXT["only be loaded once!"])*4*scale, (112*scale)-10*scale)
-			end
+			properprintF(TEXT["save game? this will"], (width*8*scale)-utf8.len(TEXT["save game? this will"])*4*scale, (112*scale)-20*scale)
+			properprintF(TEXT["overwrite last save."], (width*8*scale)-utf8.len(TEXT["overwrite last save."])*4*scale, (112*scale)-10*scale)
 			if pausemenuselected2 == 1 then
 				properprintF(">", (width*8*scale)-51*scale, (112*scale)+4*scale)
 				love.graphics.setColor(1, 1, 1, 1)
@@ -5074,7 +5062,7 @@ function game_keypressed(key, textinput)
 				else
 					playmusic()
 				end
-			elseif pausemenuoptions[pausemenuselected] == "suspend" then
+			elseif pausemenuoptions[pausemenuselected] == "save game" then
 				if dcplaying then
 					pausemenuopen = false
 					updatesizes("reset")

--- a/languages/english.json
+++ b/languages/english.json
@@ -5,6 +5,10 @@
 	"level editor": "level editor",
 	"select mappack": "select mappack",
 	"options": "options",
+	"starting a new game will": "starting a new game will",
+	"delete your existing save!": "delete your existing save!",
+	"new game": "new game",
+	"go back": "go back",
 	"select world": "select world",
 
 "^_Settings":"",
@@ -126,7 +130,6 @@
 	"link": "link",
 	"neurotoxin time: ": "neurotoxin time: ",
 	"game over": "game over",
-	"game saved!": "game saved!",
 
 "^_Pause":"",
 	"": "",
@@ -343,4 +346,5 @@
 
 "^_Notices":"",
 	"Map saved!": "Map saved!",
+	"game saved!": "game saved!",
 }

--- a/languages/english.json
+++ b/languages/english.json
@@ -126,6 +126,7 @@
 	"link": "link",
 	"neurotoxin time: ": "neurotoxin time: ",
 	"game over": "game over",
+	"game saved!": "game saved!",
 
 "^_Pause":"",
 	"": "",

--- a/main.lua
+++ b/main.lua
@@ -1624,7 +1624,7 @@ function defaultconfig()
 	reachedworlds = {}
 end
 
-function savegame()
+function writesuspendfile()
 	local st = {}
 	if marioworld == "M" then
 		marioworld = 8
@@ -1678,7 +1678,7 @@ function savegame()
 end
 
 function suspendgame()
-	savegame()
+	writesuspendfile()
 	love.audio.stop()
 	menu_load()
 end

--- a/main.lua
+++ b/main.lua
@@ -359,6 +359,10 @@ function love.load()
 		saveconfig()
 	end
 
+	if love.filesystem.getInfo("suspend") then
+		convertoldsuspendfile()
+	end
+
 	loadingbardraw(1)
 	
 	--check date for daily challenges
@@ -2993,6 +2997,17 @@ function disablecheats()
 	infinitetime = false
 	infinitelives = false
 	darkmode = false
+end
+
+function convertoldsuspendfile()
+	local s = love.filesystem.read("suspend")
+	local st = JSON:decode(s)
+
+	-- *ahem* sus. [crowd cheering]
+	local suspendedmappackfolder = st.mappackfolder
+	local suspendedmappack = st.mappack
+	love.filesystem.write(suspendedmappackfolder:gsub("mappacks", "saves") .. "/" .. suspendedmappack .. ".suspend", s)
+	love.filesystem.remove("suspend")
 end
 
 --sausage (don't ask)

--- a/main.lua
+++ b/main.lua
@@ -325,9 +325,11 @@ function love.load()
 		soundenabled = true
 	end
 	love.filesystem.createDirectory("mappacks")
+	love.filesystem.createDirectory("saves")
 	
 	love.filesystem.createDirectory("alesans_entities")
 	love.filesystem.createDirectory("alesans_entities/mappacks")
+	love.filesystem.createDirectory("alesans_entities/saves")
 	love.filesystem.createDirectory("alesans_entities/onlinemappacks")
 	love.filesystem.createDirectory("alesans_entities/characters")
 	love.filesystem.createDirectory("alesans_entities/hats")
@@ -1618,7 +1620,7 @@ function defaultconfig()
 	reachedworlds = {}
 end
 
-function suspendgame()
+function savegame()
 	local st = {}
 	if marioworld == "M" then
 		marioworld = 8
@@ -1668,18 +1670,22 @@ function suspendgame()
 	st.mappackfolder = mappackfolder
 
 	local s = JSON:encode_pretty(st)
-	love.filesystem.write("suspend", s)
-	
+	love.filesystem.write(mappackfolder:gsub("mappacks", "saves") .. "/" .. mappack .. ".suspend", s)
+end
+
+function suspendgame()
+	savegame()
 	love.audio.stop()
 	menu_load()
 end
 
 function continuegame()
-	if not love.filesystem.getInfo("suspend") then
+	savefile = mappackfolder:gsub("mappacks", "saves") .. "/" .. mappack .. ".suspend"
+	if not love.filesystem.getInfo(savefile) then
 		return
 	end
 	
-	local s = love.filesystem.read("suspend")
+	local s = love.filesystem.read(savefile)
 	local st = JSON:decode(s)
 	
 	mariosizes = {}
@@ -1718,7 +1724,7 @@ function continuegame()
 	mappackfolder = st.mappackfolder
 	
 	if (not st.collectables) then	--save the game if collectables are involved
-		love.filesystem.remove("suspend")
+		love.filesystem.remove(savefile)
 	end
 
 	loadbackground("1-1.txt")

--- a/main.lua
+++ b/main.lua
@@ -1728,10 +1728,6 @@ function continuegame()
 	end
 	mappack = st.mappack
 	mappackfolder = st.mappackfolder
-	
-	if (not st.collectables) then	--save the game if collectables are involved
-		love.filesystem.remove(savefile)
-	end
 
 	loadbackground("1-1.txt")
 

--- a/main.lua
+++ b/main.lua
@@ -1487,6 +1487,7 @@ function loadconfig(nodefaultconfig)
 			end
 		elseif s2[1] == "modmappacks" then
 			mappackfolder = "alesans_entities/mappacks"
+			savesfolder = "alesans_entities/saves"
 		elseif s2[1] == "resizable" then
 			if s2[2] then
 				resizable = (s2[2] == "true")
@@ -1618,6 +1619,7 @@ function defaultconfig()
 	mappack = "smb"
 	vsync = false
 	mappackfolder = "mappacks"
+	savesfolder = "saves"
 	fourbythree = false
 	localnick = false
 	
@@ -1674,7 +1676,7 @@ function writesuspendfile()
 	st.mappackfolder = mappackfolder
 
 	local s = JSON:encode_pretty(st)
-	love.filesystem.write(mappackfolder:gsub("mappacks", "saves") .. "/" .. mappack .. ".suspend", s)
+	love.filesystem.write(savesfolder .. "/" .. mappack .. ".suspend", s)
 end
 
 function suspendgame()
@@ -1684,7 +1686,7 @@ function suspendgame()
 end
 
 function continuegame()
-	savefile = mappackfolder:gsub("mappacks", "saves") .. "/" .. mappack .. ".suspend"
+	savefile = savesfolder .. "/" .. mappack .. ".suspend"
 	if not love.filesystem.getInfo(savefile) then
 		return
 	end

--- a/mappack.lua
+++ b/mappack.lua
@@ -26,6 +26,8 @@ function loadmappacksettings(suspended)
 			continuesublevelmusic = true
 		elseif s2[1] == "nolowtime" then
 			nolowtime = true
+		elseif s2[1] == "usesuspends" then
+			alwaysdeletesuspend = true
 		elseif s2[1] == "character" then
 			for i = 1, players do
 				setcustomplayer(s2[2], i)

--- a/menu.lua
+++ b/menu.lua
@@ -3141,6 +3141,9 @@ function createmappack()
 	s = s .. "description=the newest best  mappack?" .. "\n"
 	
 	love.filesystem.write(mappackfolder .. "/" .. mappack .. "/settings.txt", s)
+
+	-- Clean old suspend file for renamed or deleted mappacks
+	love.filesystem.remove(mappackfolder:gsub("mappacks", "saves") .. "/" .. mappack .. ".suspend")
 end
 
 function resetconfig()

--- a/menu.lua
+++ b/menu.lua
@@ -595,11 +595,34 @@ function menu_draw()
 			love.graphics.draw(playerselectarrowimg, (158-(math.ceil((utf8.len(TEXT["player game"])+2)/2)*8))*scale, 138*scale, 0, -scale, scale)
 		end
 		
+		if newgamewarning then
+			love.graphics.setColor(0, 0, 0)
+			love.graphics.rectangle("fill", 20*scale, 92*scale, 220*scale, 60*scale)
+			love.graphics.setColor(1, 1, 1)
+			drawrectangle(21, 93, 218, 58)
+			properprintF(TEXT["starting a new game will"], (130-(utf8.len(TEXT["starting a new game will"])*4))*scale, 100*scale)
+			properprintF(TEXT["delete your existing save!"], (130-(utf8.len(TEXT["delete your existing save!"])*4))*scale, 110*scale)
+			
+			if newgamewarningcursor == 1 then
+				properprintF(">", (120-((utf8.len(TEXT["new game"])+utf8.len(TEXT["go back"]))*4)-16)*scale, 130*scale)
+				love.graphics.setColor(1, 1, 1, 1)
+				properprintF(TEXT["new game"], (130-((utf8.len(TEXT["new game"])+utf8.len(TEXT["go back"]))*4)-16)*scale, 130*scale)
+				love.graphics.setColor(100/255, 100/255, 100/255, 1)
+				properprintF(TEXT["go back"], (130-((utf8.len(TEXT["new game"])-utf8.len(TEXT["go back"]))*4)+16)*scale, 130*scale)
+			else
+				properprintF(">", (120-((utf8.len(TEXT["new game"])-utf8.len(TEXT["go back"]))*4)+16)*scale, 130*scale)
+				love.graphics.setColor(100/255, 100/255, 100/255, 1)
+				properprintF(TEXT["new game"], (130-((utf8.len(TEXT["new game"])+utf8.len(TEXT["go back"]))*4)-16)*scale, 130*scale)
+				love.graphics.setColor(1, 1, 1, 1)
+				properprintF(TEXT["go back"], (130-((utf8.len(TEXT["new game"])-utf8.len(TEXT["go back"]))*4)+16)*scale, 130*scale)
+			end
+		end
+		
 		if selectworldopen then
 			love.graphics.setColor(0, 0, 0)
-			love.graphics.rectangle("fill", 30*scale, 92*scale, 200*scale, 60*scale)
+			love.graphics.rectangle("fill", 20*scale, 92*scale, 220*scale, 60*scale)
 			love.graphics.setColor(1, 1, 1)
-			drawrectangle(31, 93, 198, 58)
+			drawrectangle(21, 93, 218, 58)
 			properprintF(TEXT["select world"], (130-(utf8.len(TEXT["select world"])*4))*scale, 105*scale)
 			
 			local sc = selectworldcursor
@@ -2125,7 +2148,23 @@ function menu_keypressed(key, unicode)
 		return
 	end
 	if gamestate == "menu" then
-		if selectworldopen then
+		if newgamewarning then
+			if (key == "left" or key == "a") then
+				newgamewarningcursor = 1
+			elseif (key == "right" or key == "d") then
+				newgamewarningcursor = 2
+			elseif (key == "return" or key == "enter" or key == "kpenter" or key == " ") then
+				if (newgamewarningcursor == 1) then
+					newgamewarning = false
+					selectworld()
+				else
+					newgamewarning = false
+				end
+			elseif key == "escape" then
+				newgamewarning = false
+			end
+			return
+		elseif selectworldopen then
 			if (key == "right" or key == "d") then
 				local target = selectworldcursor+1
 				while target <= #mappacklevels and not reachedworlds[mappack][target] do
@@ -2144,7 +2183,7 @@ function menu_keypressed(key, unicode)
 				end
 			elseif (key == "return" or key == "enter" or key == "kpenter" or key == " ") then
 				selectworldopen = false
-				game_load(selectworldcursor)
+				game_load(selectworldcursor, true)
 			elseif key == "escape" then
 				selectworldopen = false
 			end
@@ -2168,7 +2207,7 @@ function menu_keypressed(key, unicode)
 			if selection == 0 then
 				game_load(true)
 			elseif selection == 1 then
-				selectworld()
+				newgame()
 			elseif selection == 2 then
 				if nofunallowed then
 					notice.new("Creator disabled the editor.", notice.white, 2)
@@ -2801,7 +2840,15 @@ function menu_mousepressed(x, y, button)
 	if gamestate == "menu" then
 		menu_updatemouseselection(x,y)
 		if mouseonselect then
-			if selectworldopen then
+			if newgamewarning then
+				if newgamewarningcursor == 1 then
+					selectworld()
+					newgamewarning = false
+				elseif newgamewarningcursor == 2 then
+					newgamewarning = false
+				end
+				return
+			elseif selectworldopen then
 				local x, y = x/scale, y/scale
 				local sc = selectworldcursor
 				local v = math.ceil(sc/8)*8-7
@@ -2833,7 +2880,7 @@ function menu_mousepressed(x, y, button)
 					end
 					if reachedworlds[mappack][i] and x > (54+(i2-1)*20) and x < (54+(i2-1)*20)+12 and y > 128 and y < 140 then
 						selectworldopen = false
-						game_load(i)
+						game_load(i, true)
 						break
 					end
 					i2 = i2 + 1
@@ -2911,7 +2958,7 @@ function menu_mousereleased(x, y, button)
 			if mouseonselect == 0 then
 				game_load(true)
 			elseif mouseonselect == 1 then
-				selectworld()
+				newgame()
 			elseif mouseonselect == 2 then
 				if nofunallowed then
 					notice.new("Creator disabled the editor.", notice.white, 2)
@@ -3162,9 +3209,19 @@ function resetconfig()
 	loadbackground("1-1.txt")
 end
 
+function newgame()
+	if love.filesystem.getInfo(savesfolder .. "/" .. mappack .. ".suspend") then
+		newgamewarning = true
+		newgamewarningcursor = 1
+		return
+	end
+
+	selectworld()
+end
+
 function selectworld()
 	if not reachedworlds[mappack] then
-		game_load()
+		game_load(nil, true)
 	end
 	
 	local noworlds = true
@@ -3176,7 +3233,7 @@ function selectworld()
 	end
 	
 	if noworlds then
-		game_load()
+		game_load(nil, true)
 		return
 	end
 	
@@ -3254,7 +3311,18 @@ function menu_filedropped(file)
 end
 
 function menu_updatemouseselection(x,y)
-	if selectworldopen then
+	if newgamewarning then
+		local x, y = x/scale, y/scale
+		local option1start = (130-((utf8.len(TEXT["new game"])+utf8.len(TEXT["go back"]))*4)-16) - 2
+		local option1end = option1start + (utf8.len(TEXT["new game"])*8) + 2
+		local option2start = (130-((utf8.len(TEXT["new game"])-utf8.len(TEXT["go back"]))*4)+16) - 2
+		local option2end = option2start + (utf8.len(TEXT["go back"])*8) + 2
+		if x > option1start and x < option1end and y > 128 and y < 140 then
+			newgamewarningcursor = 1
+		elseif x > option2start and x < option2end and y > 128 and y < 140 then
+			newgamewarningcursor = 2
+		end
+	elseif selectworldopen then
 		local x, y = x/scale, y/scale
 		local sc = selectworldcursor
 		local v = math.ceil(sc/8)*8-7

--- a/menu.lua
+++ b/menu.lua
@@ -66,7 +66,7 @@ function menu_load()
 	end
 	
 	continueavailable = false
-	if love.filesystem.getInfo(mappackfolder:gsub("mappacks", "saves") .. "/" .. mappack .. ".suspend") then
+	if love.filesystem.getInfo(savesfolder .. "/" .. mappack .. ".suspend") then
 		continueavailable = true
 	end
 	
@@ -2331,7 +2331,7 @@ function menu_keypressed(key, unicode)
 			saveconfig()
 
 			continueavailable = false
-			if love.filesystem.getInfo(mappackfolder:gsub("mappacks", "saves") .. "/" .. mappack .. ".suspend") then
+			if love.filesystem.getInfo(savesfolder .. "/" .. mappack .. ".suspend") then
 				continueavailable = true
 			end
 
@@ -2567,6 +2567,7 @@ function menu_keypressed(key, unicode)
 				elseif optionsselection == 11 then
 					if mappackfolder == "mappacks" then
 						mappackfolder = "alesans_entities/mappacks"
+						savesfolder = "alesans_entities/saves"
 						mappack = "smb"
 						loadbackground("1-1.txt")
 					end
@@ -2702,6 +2703,7 @@ function menu_keypressed(key, unicode)
 				elseif optionsselection == 11 then
 					if mappackfolder == "alesans_entities/mappacks" then
 						mappackfolder = "mappacks"
+						savesfolder = "saves"
 						mappack = "smb"
 						loadbackground("1-1.txt")
 					end
@@ -3143,7 +3145,7 @@ function createmappack()
 	love.filesystem.write(mappackfolder .. "/" .. mappack .. "/settings.txt", s)
 
 	-- Clean old suspend file for renamed or deleted mappacks
-	love.filesystem.remove(mappackfolder:gsub("mappacks", "saves") .. "/" .. mappack .. ".suspend")
+	love.filesystem.remove(savesfolder .. "/" .. mappack .. ".suspend")
 end
 
 function resetconfig()

--- a/menu.lua
+++ b/menu.lua
@@ -66,7 +66,7 @@ function menu_load()
 	end
 	
 	continueavailable = false
-	if love.filesystem.getInfo("suspend") then
+	if love.filesystem.getInfo(mappackfolder:gsub("mappacks", "saves") .. "/" .. mappack .. ".suspend") then
 		continueavailable = true
 	end
 	
@@ -2329,6 +2329,12 @@ function menu_keypressed(key, unicode)
 			end
 			gamestate = "menu"
 			saveconfig()
+
+			continueavailable = false
+			if love.filesystem.getInfo(mappackfolder:gsub("mappacks", "saves") .. "/" .. mappack .. ".suspend") then
+				continueavailable = true
+			end
+
 			if mappack == "custom_mappack" then
 				createmappack()
 			end

--- a/variables.lua
+++ b/variables.lua
@@ -767,7 +767,7 @@ gelcannonspeed = 30
 infinitetime = false
 infinitelives = false
 
-pausemenuoptions = {"resume", "suspend", "volume", "quit to", "quit to"}
+pausemenuoptions = {"resume", "save game", "volume", "quit to", "quit to"}
 pausemenuoptions2 = {"", "", "", "menu", "desktop"}
 
 guirepeatdelay = 0.07


### PR DESCRIPTION
Inspired by the number of people who dropped Retrush when they forgot to save, this PR adds tooling for map creators to add an "autosave" feature to their mappacks via the animation system. Each mappack now has its own suspend file, saved in the `saves` directory next to the `mappacks` folder. To maintain backwards compatibility, old mappacks do not autosave unless the creator adds support for it.

- Suspend files are now per-mappack
    - Each is named after its mappack folder
    - Each is saved in the `saves` directory
    - `saves` directory matches current mappack directory (`mappacks` or `alesans_entities/mappacks`) in case of mappack name collision
![2024-08-14_16-26-07](https://github.com/user-attachments/assets/e556d1f2-9117-4a5c-8033-ed9b982ac776)

- New animation to "save game progress" added to animations list
    - Map creator may call this whenever they wish
    - Option to notify the player when saving
    - Player may still manually save from the pause menu
![2024-08-14_16-19-15](https://github.com/user-attachments/assets/1156a13a-a48e-4cc9-8884-5af7bc4656af)
![2024-08-14_16-19-20](https://github.com/user-attachments/assets/67e4f387-a34d-4ae4-87fe-f77d30128194)
![2024-08-14_15-38-58](https://github.com/user-attachments/assets/00dceb75-6f99-4992-9e55-935d8c4df7a4)
