### PR TITLE
Make fencejumptime longer

### DIFF
--- a/variables.lua
+++ b/variables.lua
@@ -32,7 +32,7 @@ icefreezetime = 1 --seconds stunned when hit by ice bro balls
 groundfreezetime = 1 --seconds stunned when sledge bro ground pounded
 goombashoehop = 8 --height of hops when mario has goomba shoe
 fencespeed = 4 --speed when climbing fence
-fencejumptime = 0.05 --how long mario jumps when holding up and jumping while climbing
+fencejumptime = 0.18 --how long mario jumps when holding up and jumping while climbing
 
 --STARCOLORS
 starcolors = {}


### PR DESCRIPTION
It's too short. There doesn't need to be a char config setting for it or anything, it should just be made longer
See also #575