### PR TITLE
Added "transformDontSupersize"

### DIFF
--- a/enemy.lua
+++ b/enemy.lua
@@ -3705,7 +3705,7 @@ function enemy:transform(t, returntransform, death)
 		temp.iceblock = self.iceblock
 	end
 
-	if self.supersized then
+	if self.supersized and (not self.transformdontsupersize) then
 		supersizeentity(temp)
 	end
 	


### PR DESCRIPTION
Adds a new property which makes it so supersized enemies don't supersize after a transform, can be done without by setting "supersized" to false after a transform but this is easier and more intuitive.