### PR TITLE
Added "enemykill" transform

### DIFF
--- a/enemy.lua
+++ b/enemy.lua
@@ -2779,9 +2779,7 @@ function enemy:globalcollide(a, b, c, d, dir)
 		and a == "enemy" and (not (b.resistsenemykill or b.resistseverything)) and (not b.killsenemies) then
 
 		if self.transforms and self:gettransformtrigger("enemykill") and (not self.justspawned) then
-			if self:handlecollisiontransform("enemykill",a,b) then
-				return
-			end
+			self:transform(self:gettransformsinto("enemykill"))
 		end
 		
 		return true
@@ -2810,9 +2808,7 @@ function enemy:globalcollide(a, b, c, d, dir)
 					addpoints((firepoints[b.t] or 200), self.x, self.y)
 
 					if self.transforms and self:gettransformtrigger("enemykill") and (not self.justspawned) then
-						if self:handlecollisiontransform("enemykill",a,b) then
-							return
-						end
+						self:transform(self:gettransformsinto("enemykill"))
 					end
 					
 					return true

--- a/enemy.lua
+++ b/enemy.lua
@@ -2777,6 +2777,13 @@ function enemy:globalcollide(a, b, c, d, dir)
 	if self.killsenemies and ((self.killsenemiesonsides and (dir == "left" or dir == "right")) or (self.killsenemiesonbottom and dir == "floor") or (self.killsenemiesontop and dir == "ceil") or
 		(self.killsenemiesonleft and dir == "left") or (self.killsenemiesonright and dir == "right") or (self.killsenemiesonpassive and dir == "passive"))
 		and a == "enemy" and (not (b.resistsenemykill or b.resistseverything)) and (not b.killsenemies) then
+
+		if self.transforms and self:gettransformtrigger("enemykill") and (not self.justspawned) then
+			if self:handlecollisiontransform("enemykill",a,b) then
+				return
+			end
+		end
+		
 		return true
 	end
 	
@@ -2801,6 +2808,13 @@ function enemy:globalcollide(a, b, c, d, dir)
 						self.speedy = -(self.bounceforce or 10)
 					end
 					addpoints((firepoints[b.t] or 200), self.x, self.y)
+
+					if self.transforms and self:gettransformtrigger("enemykill") and (not self.justspawned) then
+						if self:handlecollisiontransform("enemykill",a,b) then
+							return
+						end
+					end
+					
 					return true
 				end
 			end


### PR DESCRIPTION
There is no way to recreate the fireball for use with custom powerups currently because you can't detect when a fireball kills something which seems like the most basic move you'd want to recreate.

This transform should fix this and in general is a nice transform to have.