### PR TITLE
Prevent breaking blocks under pipes or flagpoles

### DIFF
--- a/enemies/plantfire.lua
+++ b/enemies/plantfire.lua
@@ -327,7 +327,21 @@ function plantfire:globalcollide(a, b)
 		end
 		if a == "tile" then
 			local x, y = b.cox, b.coy
-			if (tilequads[map[x][y][1]].breakable or (tilequads[map[x][y][1]].debris and blockdebrisquads[tilequads[map[x][y][1]].debris])) and not portalintile(x, y) then
+			if (tilequads[map[x][y][1]].breakable or (tilequads[map[x][y][1]].debris and blockdebrisquads[tilequads[map[x][y][1]].debris])) then
+				if portalintile(x, y) or (x-1 == flagx and y == flagy) then
+					playsound(blockhitsound)
+					self.delete = true
+					return true
+				end
+				for i, p in pairs(pipes) do
+					if p.coy == y-1 and
+					   (p.cox == x+1 and (p.dir == "right" or p.dir2 == "right") or
+					    p.cox == x-1 and (p.dir == "left" or p.dir2 == "left") ) then
+						playsound(blockhitsound)
+						self.delete = true
+						return true
+					end
+				end
 				map[x][y][1] = 1
 				objects["tile"][tilemap(x, y)] = nil
 				map[x][y]["gels"] = {}

--- a/mario.lua
+++ b/mario.lua
@@ -7174,8 +7174,15 @@ function hitontop(x, y)
 end
 
 function destroyblock(x, y, v) --v = true, "nopoints"
-	if portalintile(x, y) or editormode then
+	if portalintile(x, y) or (x-1 == flagx and y == flagy) or editormode then
 		return
+	end
+	for i, p in pairs(pipes) do --don't break blocks in front of pipes
+		if p.coy == y-1 and
+		   (p.cox == x+1 and (p.dir == "right" or p.dir2 == "right") or
+		    p.cox == x-1 and (p.dir == "left" or p.dir2 == "left") ) then
+			return
+		end
 	end
 	
 	local debris = tilequads[map[x][y][1]].debris


### PR DESCRIPTION
Breaking the block under the mouth of a pipe can result in softlocks in underground levels, where designers often carelessly place bricks under the exit

https://github.com/user-attachments/assets/aeb0508e-add6-47c1-8d56-fb7f6e0cd4a8

And breaking the flagpole base is just ugly.

This pr prevents you from breaking such a block. If there's something inside, it can still be released.

Fixes #666