### PR TITLE
Clear persistent sound variables

### DIFF
--- a/game.lua
+++ b/game.lua
@@ -3950,6 +3950,7 @@ function startlevel(level, reason)
 	else
 		love.audio.stop()
 	end
+	pausedaudio = nil
 	animationsystem_load()
 
 	local sublevel = false

--- a/menu.lua
+++ b/menu.lua
@@ -2,6 +2,7 @@ local languagemenuopen = false
 local menu_updatemouseselection
 function menu_load()
 	love.audio.stop()
+	pausedaudio = nil
 	editormode = false
 	guielements = {}
 	gamestate = "menu"


### PR DESCRIPTION
Fix additional pausing-related sound issues from reloading the map from the pause menu, or having the level change while paused in online or glitchy scenarios