### PR TITLE
Add separate "Launch player x" and "Launch player y" animation actions

### DIFF
--- a/animation.lua
+++ b/animation.lua
@@ -105,6 +105,8 @@ removekeys[:player]:amount			removes keys
 setnumber:name:=/+:v				change number by something
 resetnumbers						resets all animation numbers
 launchplayer[:player]:x:y			launches player at defined speed
+launchplayerx[:player]:x			launches player at defined speed in the x axis
+launchplayery[:player]:y			launches player at defined speed in the y axis
 addtime:time						adds <seconds> time
 removetime:time						removes <seconds> time
 settime:time						sets time
@@ -753,6 +755,30 @@ function animation:update(dt)
 					local i = tonumber(string.sub(v[2], -1))
 					if objects["player"][i] then
 						objects["player"][i].speedx = tonumber(sx) or 0
+						objects["player"][i].speedy = tonumber(sy) or 0
+					end
+				end
+			elseif v[1] == "launchplayerx" then
+				local sx = v[3]:gsub("B","-")
+				if v[2] == "everyone" then
+					for i = 1, players do
+						objects["player"][i].speedx = tonumber(sx) or 0
+					end
+				else
+					local i = tonumber(string.sub(v[2], -1))
+					if objects["player"][i] then
+						objects["player"][i].speedx = tonumber(sx) or 0
+					end
+				end
+			elseif v[1] == "launchplayery" then
+				local sy = v[3]:gsub("B","-")
+				if v[2] == "everyone" then
+					for i = 1, players do
+						objects["player"][i].speedy = tonumber(sy) or 0
+					end
+				else
+					local i = tonumber(string.sub(v[2], -1))
+					if objects["player"][i] then
 						objects["player"][i].speedy = tonumber(sy) or 0
 					end
 				end

--- a/animationguiline.lua
+++ b/animationguiline.lua
@@ -1837,6 +1837,46 @@ table.insert(toenter, {name = "launchplayer",
 	}
 })
 
+table.insert(toenter, {name = "launchplayerx", 
+	t = {
+		t="action",
+		nicename="launch player x:",
+		entries={
+			{
+				t="playerselection",
+			},
+			{
+				t="text",
+				value="x speed",
+			},
+			{
+				t="numinput",
+				default="0",
+			},
+		}
+	}
+})
+
+table.insert(toenter, {name = "launchplayery", 
+	t = {
+		t="action",
+		nicename="launch player y:",
+		entries={
+			{
+				t="playerselection",
+			},
+			{
+				t="text",
+				value="y speed",
+			},
+			{
+				t="numinput",
+				default="0",
+			},
+		}
+	}
+})
+
 table.insert(toenter, {name = "setplayerlight", 
 	t = {
 		t="action",


### PR DESCRIPTION
Separates the "Launch player" animation action into two separate actions for the x and y axises so the player can be launched in one axis without affecting the other.

This would make it possible to make an animation that lets you double jump smoothly, as the normal launch player action would reset your X speed. 

Here is a video showing the actions, with an object based on the yellow orbs from Geometry Dash.

https://github.com/user-attachments/assets/763c5665-6d07-4a61-b14d-5685e89adec0

I'm not sure if the original launch player action should be removed or hidden, as it could mess with mappacks that used the original action.