### PR TITLE
Fix for Canvas/stencils

### DIFF
--- a/characters.lua
+++ b/characters.lua
@@ -454,7 +454,7 @@ local function _splitimageshaders(img, color, exclude, imagedata)
 		return love.graphics.newImage(outputdata)
 	end
 	local c = love.graphics.getCanvas()
-	love.graphics.setCanvas(output)
+	love.graphics.setCanvas{output, stencil=true}
 	love.graphics.setShader(splitShader)
 	splitShader:send("inputImage", drawable)
 	splitShader:send("splitColor", {color[1]/255,color[2]/255,color[3]/255})

--- a/shaders/init.lua
+++ b/shaders/init.lua
@@ -70,7 +70,7 @@ local function CreateShaderPass()
 	function pass:predraw()
 		if supported and self.on and self.canvas then
 			--self.canvas.canvas:clear(love.graphics.getBackgroundColor())
-			love.graphics.setCanvas(self.canvas.canvas)
+			love.graphics.setCanvas{self.canvas.canvas, stencil=true}
 			love.graphics.clear(love.graphics.getBackgroundColor()) --0.10.0
 			return self.canvas.canvas
 		end


### PR DESCRIPTION
Fixes an issue caused In Love11 where the game can crash if a canvas wasn't initialized with stencil = true.

This PR fixes #698, #693 and #671