### PR TITLE
Make ignorecheckrect boolean

### DIFF
--- a/gel.lua
+++ b/gel.lua
@@ -14,7 +14,7 @@ function gel:init(x, y, id)
 	self.active = true
 	self.category = 8
 	self.mask = {false, false, true, true, true, true, true, true, false, false, true}
-	self.ignorecheckrect = {[8] = true}
+	self.ignorecheckrect = true
 	self.gravity = 50
 	--self.autodelete = true
 	self.extremeautodelete = true

--- a/physics.lua
+++ b/physics.lua
@@ -995,7 +995,7 @@ function checkrect(x, y, width, height, list, statics, condition)
 							skip = true
 						end
 						--masktable
-						if (inobj.mask ~= nil and inobj.mask[w.category] == true) or (w.mask ~= nil and w.mask[inobj.category] == true) or (w.ignorecheckrect and w.ignorecheckrect[w.category]) then
+						if (inobj.mask ~= nil and inobj.mask[w.category] == true) or (w.mask ~= nil and w.mask[inobj.category] == true) or w.ignorecheckrect then
 							skip = true
 						end
 					end


### PR DESCRIPTION
Makes ignorecheckrect boolean, only gel uses it internally and it does a weird thing where it uses its own category,

its a bit strange and makes it hard to use by enemies so this simplifies it to a boolean value.