### PR TITLE
Sync Enemy Animation To Coin Frame

### DIFF
--- a/enemy.lua
+++ b/enemy.lua
@@ -743,7 +743,16 @@ function enemy:update(dt)
 		end
 	elseif self.animationtype == "frames" then
 		self.animationtimer = self.animationtimer + dt
-		if type(self.animationspeed) == "table" then
+		if self.synccoinanimation then -- sync to coin palette flash
+			if self.synccoinanimation == "pingpong" then
+				-- pingpong conservative images
+				self.quadi = self.animationstart + math.floor((math.min(coinanimation,7-coinanimation)-1)/3 * self.animationframes)
+			else
+				-- cycle all frames
+				self.quadi = self.animationstart + math.floor((coinanimation-1)/5 * self.animationframes)
+			end
+			self.quad = self.quadgroup[self.quadi]
+		elseif type(self.animationspeed) == "table" then
 			while self.animationtimer > self.animationspeed[self.animationtimerstage] do
 				self.animationtimer = self.animationtimer - self.animationspeed[self.animationtimerstage]
 				self.quadi = self.quadi + 1


### PR DESCRIPTION
This adds a property `synccoinanimation` to connect an enemy's frame animation to the global palette cycle used for coins and ? blocks. The setting "pingpong" will animate back and forth so you can use 3 frames instead of 5, though it also supports other amounts of frames.

It overrides `animationspeed`, so it can be applied to existing enemies without damaging them in previous versions.

(It does still get paused this way. I think this is not worth the effort it would take editing the universal entity draw code to fix it, this is plenty enough for a coin or block enemy or something)