### PR TITLE
Added new mappack setting "Disable Wall Clipping"

### DIFF
--- a/editor.lua
+++ b/editor.lua
@@ -284,12 +284,12 @@ function editor_load(player_position) --{x, y, xscroll, yscroll}
 	
 	guielements["physicsdropdown"] = guielement:new("dropdown", 294, 117, 11, changephysics, currentphysics, "mari0", "smb", "mari0-smb2j", "smb2j", "mari0-maker", "mario maker", "portal")
 	guielements["cameradropdown"] = guielement:new("dropdown", 294, 130, 11, changecamerasetting, camerasetting, "default", "centered"--[[, "forward only"]])
-	guielements["dropshadowcheckbox"] = guielement:new("checkbox", 294, 143, toggledropshadow, dropshadow, TEXT["drop shadow"])
-	guielements["realtimecheckbox"] = guielement:new("checkbox", 294, 154, togglerealtime, realtime, TEXT["real time"])
+	guielements["dropshadowcheckbox"] = guielement:new("checkbox", 286, 143, toggledropshadow, dropshadow, TEXT["drop shadow"])
+	guielements["realtimecheckbox"] = guielement:new("checkbox", 286, 154, togglerealtime, realtime, TEXT["real time"])
 	local _, count = TEXT["real time"]:gsub("\n", '')
-	guielements["continuemusiccheckbox"] = guielement:new("checkbox", 294, guielements["realtimecheckbox"].y+11+10*count, togglecontinuemusic, continuesublevelmusic, TEXT["cont. music"])
+	guielements["continuemusiccheckbox"] = guielement:new("checkbox", 286, guielements["realtimecheckbox"].y+11+10*count, togglecontinuemusic, continuesublevelmusic, TEXT["cont. music"])
 	_, count = TEXT["cont. music"]:gsub("\n", '')
-	guielements["nolowtimecheckbox"] = guielement:new("checkbox", 294, guielements["continuemusiccheckbox"].y+11+10*count, togglenolowtime, nolowtime, TEXT["no low time"])
+	guielements["nolowtimecheckbox"] = guielement:new("checkbox", 286, guielements["continuemusiccheckbox"].y+11+10*count, togglenolowtime, nolowtime, TEXT["no low time"])
 	guielements["disablewallclippingcheckbox"] = guielement:new("checkbox", 286, guielements["nolowtimecheckbox"].y+11+10*count, togglewallclipping, disablewallclipping, TEXT["disable wall clipping"])
 
 	--MAPS

--- a/editor.lua
+++ b/editor.lua
@@ -290,6 +290,7 @@ function editor_load(player_position) --{x, y, xscroll, yscroll}
 	guielements["continuemusiccheckbox"] = guielement:new("checkbox", 294, guielements["realtimecheckbox"].y+11+10*count, togglecontinuemusic, continuesublevelmusic, TEXT["cont. music"])
 	_, count = TEXT["cont. music"]:gsub("\n", '')
 	guielements["nolowtimecheckbox"] = guielement:new("checkbox", 294, guielements["continuemusiccheckbox"].y+11+10*count, togglenolowtime, nolowtime, TEXT["no low time"])
+	guielements["disablewallclippingcheckbox"] = guielement:new("checkbox", 286, guielements["nolowtimecheckbox"].y+11+10*count, togglewallclipping, disablewallclipping, TEXT["disable wall clipping"])
 
 	--MAPS
 	guielements["savebutton2"] = guielement:new("button", 300, 196, TEXT["save level"], guielements["savebutton"].func, 0, nil, 2.4, 94, true)
@@ -2769,6 +2770,7 @@ function editor_draw()
 			guielements["realtimecheckbox"]:draw()
 			guielements["continuemusiccheckbox"]:draw()
 			guielements["nolowtimecheckbox"]:draw()
+			guielements["disablewallclippingcheckbox"]:draw()
 			
 			properprintF(TEXT["lives:"], 228*scale, 106*scale)
 			guielements["livesincrease"]:draw()
@@ -3441,6 +3443,7 @@ function toolstab()
 	guielements["realtimecheckbox"].active = true
 	guielements["continuemusiccheckbox"].active = true
 	guielements["nolowtimecheckbox"].active = true
+	guielements["disablewallclippingcheckbox"].active = true
 end
 
 function mapstab()
@@ -7737,6 +7740,9 @@ function savesettings()
 	if nolowtime then
 		s = s .. "nolowtime=t\n"
 	end
+	if disablewallclipping then
+		s = s .. "disablewallclipping=t\n"
+	end
 	
 	love.filesystem.createDirectory( mappackfolder )
 	love.filesystem.createDirectory( mappackfolder .. "/" .. mappack )
@@ -7974,6 +7980,15 @@ function togglenolowtime(var)
 		nolowtime = not nolowtime
 	end
 	guielements["nolowtimecheckbox"].var = nolowtime
+end
+
+function togglewallclipping(var)
+	if var ~= nil then
+		disablewallclipping = var
+	else
+		disablewallclipping = not disablewallclipping
+	end
+	guielements["disablewallclippingcheckbox"].var = disablewallclipping
 end
 
 function updatescrollfactor()

--- a/game.lua
+++ b/game.lua
@@ -47,6 +47,7 @@ function game_load(suspended, deletesuspend)
 	realtime = false
 	continuesublevelmusic = false
 	nolowtime = false
+	disablewallclipping = false
 	nocoinlimit = false
 	alwaysdeletesuspend = false
 	setphysics(1)

--- a/languages/english.json
+++ b/languages/english.json
@@ -240,6 +240,7 @@
 		"real time": "real time",
 		"cont. music": "cont. music",
 		"no low time": "no low time",
+		"disable wall clipping": "disable wall\nclipping",
 		"save settings": "save settings",
 		"tool descriptions": [
 			"to link testing equipment, drag\na line from the red devices to\na yellow activator to turn them\ngreen and connected.",

--- a/mappack.lua
+++ b/mappack.lua
@@ -26,6 +26,8 @@ function loadmappacksettings(suspended)
 			continuesublevelmusic = true
 		elseif s2[1] == "nolowtime" then
 			nolowtime = true
+		elseif s2[1] == "disablewallclipping" then
+			disablewallclipping = true
 		elseif s2[1] == "usesuspends" then
 			alwaysdeletesuspend = true
 		elseif s2[1] == "character" then

--- a/mario.lua
+++ b/mario.lua
@@ -4433,6 +4433,12 @@ function mario:setsize(size, oldsize)
 		end
 		self.width = width
 		self.height = height
+
+		if disablewallclipping and self.animation ~= "grow1" and self.animation ~= "grow2" then
+			if size ~= 8 and self.gravitydir == "down" and checkintile(self.x, self.y-self.height, self.width, self.height, {}, self, "ignoreplatforms") then
+				self:duck(true)
+			end
+		end
 	end
 	
 	if ducking and (size > 1 or self.characterdata.smallducking) and size ~= 5 and size ~= 8 and size ~= 16 then
@@ -6472,7 +6478,7 @@ function mario:passivecollide(a, b)
 			end
 		end
 	end
-	if self.passivemoved == false then
+	if self.passivemoved == false and (not disablewallclipping) then
 		self.passivemoved = true
 		if a == "tile" then
 			local x, y = b.cox, b.coy
@@ -7639,16 +7645,19 @@ function mario:cubeemancipate()
 end
 
 function mario:duck(ducking, size, dontmove, playercontrols) --goose
-	if self.ducking and (self.quicksand or mariomakerphysics) and self.gravitydir == "down" and playercontrols then
-		--[[dont unduck if clipping
+	--[[if self.ducking and (self.quicksand or mariomakerphysics) and self.gravitydir == "down" and playercontrols then
+		dont unduck if clipping
 		if self.size ~= 14 and
 			checkintile(self.x, self.y-self.height, self.width, self.height, tileentities, self, "ignoreplatforms") then
 			return false
-		end]]
-	end
+		end
+	end]]
 	if self.ducking and playercontrols then
 		--dont unduck if under clearpipe
 		if checkinclearpipesegment(self.x, self.y-self.height, self.width, self.height) then
+			return false
+		end
+		if disablewallclipping and self.gravitydir == "down" and checkintile(self.x, self.y-self.height, self.width, self.height, {}, self, "ignoreplatforms") then
 			return false
 		end
 	end


### PR DESCRIPTION
I've never really liked this feature when it comes to map making, so i made a setting to disable it.

This disables passive movement as well as restrictions for un-crouching and auto ducking when under blocks.

NOTE: Mega Mario is still a problem. He's a special child and I need to think, this is why this PR is a draft.